### PR TITLE
add workflow keepalive

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,3 +130,11 @@ jobs:
           -f "name=LAST_RELEASE_DIGEST" -f "value=${{ needs.check-digest.outputs.new_digest }}"
         env:
           GH_TOKEN: ${{ secrets.VARIABLE_WRITE_KEY }}
+
+  workflow-keepalive:
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'schedule'
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1.2.1


### PR DESCRIPTION
github disables scheduled workflows if there is no activity (read: commits) on the repo for 60 days

> In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days.

source: https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows
